### PR TITLE
Enable comment syntax highlighting in jsx attributes

### DIFF
--- a/grammars/reason.json
+++ b/grammars/reason.json
@@ -221,7 +221,8 @@
           ]
         },
         { "include": "#jsx-attributes" },
-        { "include": "#jsx-body" }
+        { "include": "#jsx-body" },
+        { "include": "#comment" }
       ]
     },
     "jsx-tail": {


### PR DESCRIPTION
Since this repo is the "source of truth" for `reason.json` which is used by several other repos (such as https://github.com/jaredly/reason-language-server and https://github.com/reasonml-editor/vscode-reasonml among others) I wanted to submit this PR here first.

If approved, I'll submit the PRs to update the other repos.