### PR TITLE
Fix runaway comment highlighting

### DIFF
--- a/grammars/reason.json
+++ b/grammars/reason.json
@@ -98,7 +98,6 @@
       ]
     },
     "comment": {
-      "name": "comment",
       "patterns": [
         { "include": "#comment-line" },
         { "include": "#comment-block-doc" },
@@ -106,28 +105,35 @@
       ]
     },
     "comment-line": {
-      "begin": "(^[ \\t]+)?((//))",
-      "end": "(?=^)",
-      "name": "comment.line",
-      "patterns": [
-        { "include": "#comment" }
-      ]
+      "begin": "(^[ \\t]+)?(//)",
+      "end": "$",
+      "name": "comment.line.double-slash",
+      "beginCaptures": {
+        "1": { "name": "punctuation.whitespace.leading" },
+        "2": { "name": "punctuation.definition.comment" }
+      }
     },
     "comment-block": {
       "begin": "/\\*",
       "end": "\\*/",
       "name": "comment.block",
-      "patterns": [
-        { "include": "#comment" }
-      ]
+      "beginCaptures": {
+        "0": { "name": "punctuation.definition.comment.begin" }
+      },
+      "endCaptures":   {
+        "0": { "name": "punctuation.definition.comment.end" }
+      }
     },
     "comment-block-doc": {
       "begin": "/\\*\\*(?!/)",
       "end": "\\*/",
       "name": "comment.block.documentation",
-      "patterns": [
-        { "include": "#comment" }
-      ]
+      "beginCaptures": {
+        "0": { "name": "punctuation.definition.comment.begin" }
+      },
+      "endCaptures":   {
+        "0": { "name": "punctuation.definition.comment.end" }
+      }
     },
     "condition-lhs": {
       "begin": "(?<![#\\-:!?.@*/&%^+<=>|~$\\\\])([\\?])(?![#\\-:!?.@*/&%^+<=>|~$\\\\])",


### PR DESCRIPTION
This PR fixes a highlighting issue on GitHub, which [you can clearly see here](https://github.com/reasonml-community/bs-webapi-incubator/blob/bc0badfc40420e271f4b1703dd9c43bed7d68b13/src/Webapi/Webapi__Dom/Webapi__Dom__Node.re#L32-L55).

* Block comments containing double-slashes (such as a URL) were spilling onto lines outside the closing `*/`. The culprit was the recursive and needless inclusion of the other `#comment-*` patterns inside a successful match.

* The `name` property of the `#comments` rule is superfluous; names only apply when a pattern-type property exists in the same rule-block (such as `match`, `begin`, and `end` fields).

* Minor refinements were made to the scope-names of the comment patterns to be consistent with [established TextMate naming conventions](https://macromates.com/manual/en/language_grammars#naming_conventions).

**Resolves:** github/linguist#4533.