### PR TITLE
Add res/resi support

### DIFF
--- a/grammars/bucklescript-hover-type.json
+++ b/grammars/bucklescript-hover-type.json
@@ -1,0 +1,8 @@
+{
+  "scopeName": "source.bucklescript.hover.type",
+  "patterns": [
+    { "include": "source.bucklescript#signature-expression" },
+    { "include": "source.bucklescript#module-item-type" },
+    { "include": "source.bucklescript#type-expression" }
+  ]
+}

--- a/grammars/bucklescript-hover-type.json
+++ b/grammars/bucklescript-hover-type.json
@@ -1,8 +1,0 @@
-{
-  "scopeName": "source.bucklescript.hover.type",
-  "patterns": [
-    { "include": "source.bucklescript#signature-expression" },
-    { "include": "source.bucklescript#module-item-type" },
-    { "include": "source.bucklescript#type-expression" }
-  ]
-}

--- a/grammars/bucklescript.json
+++ b/grammars/bucklescript.json
@@ -1,0 +1,455 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "BuckleScript",
+  "scopeName": "source.bucklescript",
+  "fileTypes": [
+    "res",
+    "resi"
+  ],
+  "repository": {
+    "RE_IDENT": {
+      "match": "[a-z_][0-9a-zA-Z_]*"
+    },
+    "RE_ATTRIBUTE": {
+      "match": "[A-Za-z_][A-Za-z0-9_\\.]*"
+    },
+    "RE_MODULE_IDENT": {
+      "name": "entity.name.namespace",
+      "match": "[A-Z_][0-9a-zA-Z_]*"
+    },
+    "RE_KEYWORDS": {
+      "name": "keyword.control",
+      "match": "\\b(and|as|assert|begin|class|constraint|done|downto|exception|external|fun|functor|inherit|lazy|let|pub|mutable|new|nonrec|object|of|or|pri|rec|then|to|val|virtual|try|catch|finally|do|else|for|if|switch|while|import|library|export|module|in|raise|private)\\b"
+    },
+    "RE_LITERAL": {
+      "name": "constant.language",
+      "match": "\\b(true|false)\\b"
+    },
+    "commentLine": {
+      "match": "//.*",
+      "name": "comment.line"
+    },
+    "commentBlock": {
+      "name": "comment.block",
+      "begin": "/\\*",
+      "end": "\\*/"
+    },
+    "punctuations": {
+      "patterns": [
+        {
+          "match": "~",
+          "name": "punctuation.definition.keyword"
+        },
+        {
+          "match": ";",
+          "name": "punctuation.terminator"
+        },
+        {
+          "match": "\\.",
+          "name": "punctuation.accessor"
+        },
+        {
+          "match": "\\,",
+          "name": "punctuation.separator"
+        },
+        {
+          "match": "\\?|:",
+          "name": "punctuation.separator"
+        },
+        {
+          "match": "\\|(?!\\|)",
+          "name": "punctuation.separator"
+        },
+        {
+          "match": "\\{",
+          "name": "punctuation.section.braces.begin"
+        },
+        {
+          "match": "\\}",
+          "name": "punctuation.section.braces.end"
+        },
+        {
+          "match": "\\(",
+          "name": "punctuation.section.parens.begin"
+        },
+        {
+          "match": "\\)",
+          "name": "punctuation.section.parens.end"
+        }
+      ]
+    },
+    "storage": {
+      "patterns": [
+        {
+          "match": "\\btype\\b",
+          "name": "storage.type"
+        }
+      ]
+    },
+    "keyword": {
+      "patterns": [
+        {
+          "include": "#RE_KEYWORDS"
+        }
+      ]
+    },
+    "constant": {
+      "patterns": [
+        {
+          "include": "#RE_LITERAL"
+        }
+      ]
+    },
+    "string": {
+      "patterns": [
+        {
+          "name": "string.quoted.double",
+          "begin": "\"",
+          "end": "\"",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.begin"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "punctuation.definition.string.end"
+            }
+          },
+          "patterns": [
+            {
+              "name": "constant.character.escape",
+              "match": "\\\\."
+            }
+          ]
+        },
+        {
+          "contentName": "string.quoted.other",
+          "begin": "([a-z_][0-9a-zA-Z_]*)?(`)",
+          "end": "`",
+          "beginCaptures": {
+            "1": {
+              "name": "variables.annotation"
+            },
+            "2": {
+              "name": "string.quoted.other punctuation.definition.string.begin"
+            }
+          },
+          "endCaptures": {
+            "1": {
+              "name": "string.quoted.other punctuation.definition.string.end"
+            }
+          }
+        }
+      ]
+    },
+    "function": {
+      "patterns": [
+        {
+          "match": "=>",
+          "name": "storage.type.function keyword.declaration.function"
+        }
+      ]
+    },
+    "character": {
+      "patterns": [
+        {
+          "match": "'[\\x00-\\x7F]'",
+          "name": "string.quoted.single"
+        }
+      ]
+    },
+    "number": {
+      "patterns": [
+        {
+          "match": "\\b(0[xX][a-fA-F0-9_]+[Lln]?|0[oO][0-7_]+[Lln]?|0[bB][01_]+[Lln]?|[0-9][0-9_]*([Lln]|(\\.[0-9_]+)?([eE][-+]?[0-9_]+)?)?)\\b",
+          "name": "constant.numeric"
+        }
+      ]
+    },
+    "operator": {
+      "patterns": [
+        {
+          "match": "->|\\|\\||&&|\\+\\+|\\*\\*|\\+\\.|\\+|-\\.|-|\\*\\.|\\*|/\\.|/|\\.\\.\\.|\\.\\.|\\|>|===|==|\\^|:=|!|>=|<=",
+          "name": "keyword.operator"
+        }
+      ]
+    },
+    "assignment": {
+      "patterns": [
+        {
+          "match": "=",
+          "name": "keyword.operator.assignment"
+        }
+      ]
+    },
+    "constructor": {
+      "patterns": [
+        {
+          "match": "\\b[A-Z][0-9a-zA-Z_]*\\b",
+          "name": "variable.function variable.other"
+        },
+        {
+          "match": "(#)[a-zA-Z][0-9a-zA-Z_]*\\b",
+          "captures": {
+            "1": {
+              "name": "punctuation.definition.keyword"
+            }
+          }
+        }
+      ]
+    },
+    "array": {
+      "patterns": [
+        {
+          "match": "\\[",
+          "name": "punctuation.section.brackets.begin"
+        },
+        {
+          "match": "\\]",
+          "name": "punctuation.section.brackets.end"
+        }
+      ]
+    },
+    "list": {
+      "patterns": [
+        {
+          "match": "\\b(list)(\\[)",
+          "captures": {
+            "1": {
+              "name": "keyword"
+            },
+            "2": {
+              "name": "punctuation.section.brackets.begin"
+            }
+          }
+        },
+        {
+          "match": "\\]",
+          "name": "punctuation.section.brackets.end"
+        }
+      ]
+    },
+    "objectAccess": {
+      "patterns": [
+        {
+          "match": "\\b[a-z_][0-9a-zA-Z_]*(\\[)",
+          "captures": {
+            "1": {
+              "name": "punctuation.section.brackets.begin"
+            }
+          }
+        },
+        {
+          "match": "\\]",
+          "name": "punctuation.section.brackets.end"
+        }
+      ]
+    },
+    "attribute": {
+      "patterns": [
+        {
+          "match": "(@@?)([A-Za-z_][A-Za-z0-9_\\.]*)",
+          "captures": {
+            "1": {
+              "name": "storage.modifier punctuation.definition.annotation"
+            },
+            "2": {
+              "name": "variable.annotation"
+            }
+          }
+        },
+        {
+          "match": "(%%?)([A-Za-z_][A-Za-z0-9_\\.]*)",
+          "captures": {
+            "1": {
+              "name": "storage.modifier punctuation.definition.annotation"
+            },
+            "2": {
+              "name": "variable.annotation"
+            }
+          }
+        }
+      ]
+    },
+    "jsx": {
+      "patterns": [
+        {
+          "match": "<>|</>|/>"
+        },
+        {
+          "match": "</([A-Z_][0-9a-zA-Z_]*)",
+          "captures": {
+            "1": {
+              "name": "entity.name.namespace"
+            }
+          }
+        },
+        {
+          "match": "</([A-Z_][0-9a-zA-Z_]*)"
+        },
+        {
+          "match": "<([A-Z_][0-9a-zA-Z_]*)",
+          "captures": {
+            "1": {
+              "name": "entity.name.namespace"
+            }
+          }
+        }
+      ]
+    },
+    "openOrIncludeModule": {
+      "patterns": [
+        {
+          "match": "\\b(open|include)\\s+([A-Z_][0-9a-zA-Z_]*((\\.)([A-Z_][0-9a-zA-Z_]*))*)",
+          "captures": {
+            "1": {
+              "name": "keyword"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "include": "#moduleAccessEndsWithModule"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "match": "\\b(open|include)\\s*",
+          "name": "keyword"
+        }
+      ]
+    },
+    "moduleAccessEndsWithModule": {
+      "patterns": [
+        {
+          "match": "[A-Z_][0-9a-zA-Z_]*",
+          "name": "entity.name.namespace"
+        },
+        {
+          "match": "(\\.)([A-Z_][0-9a-zA-Z_]*)",
+          "captures": {
+            "1": {
+              "name": "punctuation.accessor"
+            },
+            "2": {
+              "name": "entity.name.namespace"
+            }
+          }
+        }
+      ]
+    },
+    "moduleAccess": {
+      "patterns": [
+        {
+          "match": "\\b([A-Z_][0-9a-zA-Z_]*)(\\.)",
+          "captures": {
+            "1": {
+              "name": "entity.name.namespace"
+            },
+            "2": {
+              "name": "punctuation.accessor"
+            }
+          }
+        }
+      ]
+    },
+    "moduleDeclaration": {
+      "patterns": [
+        {
+          "match": "\\b(module)\\s+(type\\s+)?(of\\s+)?([A-Z_][0-9a-zA-Z_]*)",
+          "captures": {
+            "1": {
+              "name": "keyword"
+            },
+            "2": {
+              "name": "keyword"
+            },
+            "3": {
+              "name": "keyword"
+            },
+            "4": {
+              "name": "entity.name.namespace"
+            }
+          },
+          "patterns": [
+            {
+              "match": "\\s*:\\s*([A-Z_][0-9a-zA-Z_]*)",
+              "captures": {
+                "1": {
+                  "name": "entity.name.namespace"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "patterns": [
+    {
+      "include": "#storage"
+    },
+    {
+      "include": "#constant"
+    },
+    {
+      "include": "#commentLine"
+    },
+    {
+      "include": "#commentBlock"
+    },
+    {
+      "include": "#character"
+    },
+    {
+      "include": "#string"
+    },
+    {
+      "include": "#attribute"
+    },
+    {
+      "include": "#function"
+    },
+    {
+      "include": "#list"
+    },
+    {
+      "include": "#objectAccess"
+    },
+    {
+      "include": "#array"
+    },
+    {
+      "include": "#jsx"
+    },
+    {
+      "include": "#operator"
+    },
+    {
+      "include": "#assignment"
+    },
+    {
+      "include": "#number"
+    },
+    {
+      "include": "#openOrIncludeModule"
+    },
+    {
+      "include": "#moduleDeclaration"
+    },
+    {
+      "include": "#moduleAccess"
+    },
+    {
+      "include": "#constructor"
+    },
+    {
+      "include": "#keyword"
+    },
+    {
+      "include": "#punctuations"
+    }
+  ]
+}

--- a/settings/language-reason.json
+++ b/settings/language-reason.json
@@ -5,7 +5,16 @@
       "foldEndPattern": "^\\s*\\}|^\\s*\\]|^\\s*\\)",
       "increaseIndentPattern": "(?x) \\{ [^}\"']* $ | \\[ [^\\]\"']* $ | \\( [^)\"']* $",
       "decreaseIndentPattern": "(?x) ^ \\s* (\\s* /[*] .* [*]/ \\s*)* [}\\])]",
-      "preferredLineLength": 110
+      "preferredLineLength": 80
+    }
+  },
+  ".source.bucklescript": {
+    "editor": {
+      "commentStart": "// ",
+      "foldEndPattern": "^\\s*\\}|^\\s*\\]|^\\s*\\)",
+      "increaseIndentPattern": "(?x) \\{ [^}\"']* $ | \\[ [^\\]\"']* $ | \\( [^)\"']* $",
+      "decreaseIndentPattern": "(?x) ^ \\s* (\\s* /[*] .* [*]/ \\s*)* [}\\])]",
+      "preferredLineLength": 80
     }
   }
 }

--- a/settings/language-reason.json
+++ b/settings/language-reason.json
@@ -5,7 +5,7 @@
       "foldEndPattern": "^\\s*\\}|^\\s*\\]|^\\s*\\)",
       "increaseIndentPattern": "(?x) \\{ [^}\"']* $ | \\[ [^\\]\"']* $ | \\( [^)\"']* $",
       "decreaseIndentPattern": "(?x) ^ \\s* (\\s* /[*] .* [*]/ \\s*)* [}\\])]",
-      "preferredLineLength": 80
+      "preferredLineLength": 110
     }
   },
   ".source.bucklescript": {
@@ -14,7 +14,7 @@
       "foldEndPattern": "^\\s*\\}|^\\s*\\]|^\\s*\\)",
       "increaseIndentPattern": "(?x) \\{ [^}\"']* $ | \\[ [^\\]\"']* $ | \\( [^)\"']* $",
       "decreaseIndentPattern": "(?x) ^ \\s* (\\s* /[*] .* [*]/ \\s*)* [}\\])]",
-      "preferredLineLength": 80
+      "preferredLineLength": 110
     }
   }
 }

--- a/snippets/language-reason.json
+++ b/snippets/language-reason.json
@@ -36,5 +36,31 @@
       "prefix": "try",
       "body": "try (${1:expression}) {\n| ${2:firstException} => ${3:firstHandler}\n};"
     }
+  },
+  ".source.bucklescript": {
+    "BuckleScript: Type alias": {
+      "prefix": "ta",
+      "body": "type ${1:t} = ${2:typ}"
+    },
+    "BuckleScript: Let Binding": {
+      "prefix": "lb",
+      "body": "let ${1:name} = ${2:value}"
+    },
+    "BuckleScript: Let Function": {
+      "prefix": "lf",
+      "body": "let ${1:funcName} = (${2:args}) => {\n  $0\n}"
+    },
+    "BuckleScript: Module": {
+      "prefix": "mo",
+      "body": "module ${1:Module} = {\n  ${0}\n}"
+    },
+    "BuckleScript: Switch Pattern Match": {
+      "prefix": "sw",
+      "body": "switch ${1:expression} {\n| ${2:firstCase} => ${3:result}\n}"
+    },
+    "BuckleScript: Try-catch": {
+      "prefix": "try",
+      "body": "try ${1:expression} catch {\n| ${2:firstException} => ${3:firstHandler}\n}"
+    }
   }
 }


### PR DESCRIPTION
@chenglou I added `source.bucklescript`.

Few notes:
1. AFAICT jsx highlighting is not yet implemented.
2. I'm not sure what `[grammar]-hover-type.json` does so I just copied it over.
3. Also, copied over `editor` settings in `settings/language-reason.json`. Seems like it works, not sure if it requires updates.
4. Changed `preferredLineLength` to `80` since it is the current `refmt` default.
5. I also tried to plug RLS but it didn't work. Then I checked VSCode plugin and apparently LSP support for the new syntax wasn't implemented yet. It's highlighting only.